### PR TITLE
Add --teammate-model flag for explicit teammate model control

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <div align="center">
 
-# pr-review.sh
+# reviewer
 
-**Automated PR code review powered by Claude Code agent teams**
+**AI-powered PR code review with Claude Code agent teams**
 
-Git worktrees for full isolation. Four specialist reviewers. Parallel reviews in iTerm2, tmux, or background processes.
+Four specialist reviewers. Full git worktree isolation. Parallel reviews in iTerm2, tmux, or background.
 
 [![Shell](https://img.shields.io/badge/shell-bash%205.0%2B-blue)](#requirements)
-[![Tests](https://img.shields.io/badge/tests-160%20passing-brightgreen)](#testing)
+[![Tests](https://img.shields.io/badge/tests-219%20passing-brightgreen)](#testing)
 [![macOS](https://img.shields.io/badge/platform-macOS-lightgrey)](#requirements)
 [![License](https://img.shields.io/badge/license-MIT-green)](#license)
 
@@ -15,82 +15,84 @@ Git worktrees for full isolation. Four specialist reviewers. Parallel reviews in
 
 ---
 
-## Table of Contents
-
-- [Why](#why)
-- [Quick Start](#quick-start)
-- [Setup](#setup)
-- [Requirements](#requirements)
-- [Usage](#usage)
-- [Parallel Reviews](#parallel-reviews)
-- [How It Works](#how-it-works)
-- [Examples](#examples)
-- [Environment Files](#environment-files)
-- [Testing](#testing)
-- [Troubleshooting](#troubleshooting)
-- [Security](#security)
-- [Uninstall](#uninstall)
-- [Contributing](#contributing)
-- [License](#license)
-
----
-
-## Why
-
-Manual code reviews are slow, inconsistent, and drain senior engineers. This script launches a **team of four AI specialists** -- code quality, security, logic/correctness, and architecture -- against any GitHub PR. Each reviewer works from a fully isolated git worktree with access to the real test suite, linters, and build tools. Reviews are thorough, structured, and delivered in minutes.
-
----
-
 ## Quick Start
 
 ```bash
-# 1. Install dependencies (macOS)
-brew install gh jq claude
-gh auth login
+brew install gh jq claude && gh auth login
 
-# 2. Clone and run
 git clone git@github.com:Reidmen/reviewer.git ~/reviewer
-~/reviewer/pr_review.sh 42
+~/reviewer/reviewer.sh 42
 ```
 
-That's it. The script handles worktree creation, environment setup, and agent orchestration automatically.
+Multiple PRs open in parallel tabs automatically:
 
-> **Tip:** Pass multiple PR numbers to review them in parallel -- each opens in its own terminal tab.
->
-> ```bash
-> ~/reviewer/pr_review.sh 42 43 44
-> ```
+```bash
+~/reviewer/reviewer.sh 42 43 44
+```
+
+---
+
+## Workflow
+
+```
+  reviewer.sh 42
+       │
+       ▼
+  ┌─────────┐     ┌──────────┐     ┌──────────┐
+  │ Fetch PR │────▶│ Worktree │────▶│ Copy env │
+  │ metadata │     │ checkout │     │ & config │
+  │ & diff   │     │ isolated │     │ files    │
+  └─────────┘     └──────────┘     └────┬─────┘
+                                        │
+                    ┌───────────────────┐│
+                    │ Claude Code       │▼
+       ┌────────────┤ Agent Team  ┌──────────┐
+       │            └─────────────┤ Lead     │
+       │                          │ Agent    │
+       │                          └────┬─────┘
+       │                               │
+       │            ┌──────────────────┼──────────────────┐
+       │            │                  │                  │
+       │       ┌────▼─────┐     ┌─────▼────┐     ┌──────▼─────┐
+       │       │ Code     │     │ Security │     │ Logic &    │
+       │       │ Quality  │     │ Auditor  │     │ Correctness│
+       │       └──────────┘     └──────────┘     └────────────┘
+       │
+  ┌────▼──────────┐
+  │ Architecture  │
+  │ Reviewer      │
+  └───────────────┘
+       │
+       ▼
+  ┌──────────────────────────────────────────┐
+  │ REVIEW.md                                │
+  │                                          │
+  │  Verdict  ·  Test runs  ·  Findings      │
+  │  File-by-file notes  ·  Suggestions      │
+  └──────────────────────────────────────────┘
+```
+
+Each reviewer can run tests, linters, and type-checkers inside the worktree. The lead agent synthesizes all findings into a structured review.
 
 ---
 
 ## Setup
 
-### Install dependencies
-
 ```bash
+# Install dependencies
 brew install gh jq claude
 gh auth login
-```
 
-### Install the script
-
-`pr_review.sh` is a single self-contained Bash script. Clone it somewhere and run it directly -- no build step, no package manager.
-
-```bash
-# Option A: Clone and use directly
+# Option A: Run directly
 git clone git@github.com:Reidmen/reviewer.git ~/reviewer
-~/reviewer/pr_review.sh 42
+~/reviewer/reviewer.sh 42
 
-# Option B: Symlink to your PATH for convenience
-ln -s ~/reviewer/pr_review.sh /usr/local/bin/pr_review
-pr_review 42
-
-# Option C: Copy the script anywhere you like
-cp ~/reviewer/pr_review.sh ~/bin/pr_review.sh
-~/bin/pr_review.sh 42
+# Option B: Symlink to PATH
+ln -s ~/reviewer/reviewer.sh /usr/local/bin/reviewer
+reviewer 42
 ```
 
-Run `pr_review.sh` from inside any git repository that has a GitHub remote. The script auto-detects the repo, fetches the PR, and creates an isolated worktree under `~/.pr_reviewer/` -- your working directory is never touched.
+Run from inside any git repo with a GitHub remote. The script auto-detects the repo and creates an isolated worktree under `~/.reviewer/`.
 
 ---
 
@@ -98,68 +100,45 @@ Run `pr_review.sh` from inside any git repository that has a GitHub remote. The 
 
 | Tool | Install | Purpose |
 |------|---------|---------|
-| `gh` | `brew install gh` then `gh auth login` | GitHub CLI |
-| `git` | Pre-installed on macOS | Git 2.15+ for worktree support |
+| `gh` | `brew install gh` + `gh auth login` | GitHub CLI |
+| `git` | Pre-installed on macOS | Git 2.15+ (worktrees) |
 | `claude` | `brew install claude` | Claude Code CLI |
 | `jq` | `brew install jq` | JSON processing |
-
-> **Note:** This tool uses the Claude API through Claude Code. You need an active Anthropic API key or a Claude Code subscription. Each PR review typically uses 30--75 agentic turns depending on the `--max-turns` setting.
 
 ---
 
 ## Usage
 
 ```
-./pr_review.sh <PR_NUMBER...> [OPTIONS]
+reviewer.sh <PR_NUMBER...> [OPTIONS]
 ```
 
-### Core Options
+### Options
 
 | Flag | Description | Default |
 |------|-------------|---------|
-| `-r, --repo <owner/repo>` | Target GitHub repository | Auto-detected |
-| `-d, --dir <path>` | Parent directory for worktrees | `~/.pr_reviewer/` |
-| `-m, --model <model>` | Claude model for the lead agent | `opus` |
+| `-m, --model <model>` | Claude model for lead agent | `opus` |
+| `-tm, --teammate-model <model>` | Model for teammate agents | same as `--model` |
 | `-b, --max-turns <N>` | Max agentic turns per PR | `50` |
-| `-h, --help` | Show help | -- |
-
-### Output Options
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `-o, --output <path>` | Write review to file (single-PR, non-interactive) | -- |
+| `-r, --repo <owner/repo>` | Target repository | auto-detected |
+| `-o, --output <path>` | Write review to file | -- |
 | `-c, --cleanup` | Remove worktree after review | `false` |
-| `--no-color` | Disable colored output | Auto-detected |
-
-### Agent Options
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `-t, --no-teams` | Use subagents instead of agent teams | `false` |
-| `--no-skip-permissions` | Require manual approval for each tool use | `false` |
-
-### Environment Options
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `-e, --env-files <globs>` | Extra file patterns to copy (comma-separated) | Built-in list |
-| `--no-env-copy` | Skip copying env/config files | `false` |
-
-### Terminal Options
-
-| Flag | Description | Default |
-|------|-------------|---------|
-| `--tabs <mode>` | Tab mode: `auto`, `iterm`, `tmux`, `bg` | `auto` |
+| `-t, --no-teams` | Use subagents instead of teams | `false` |
+| `-e, --env-files <globs>` | Extra env file patterns | built-in list |
+| `--no-env-copy` | Skip env/config copying | `false` |
+| `-d, --dir <path>` | Worktree parent directory | `~/.reviewer/` |
+| `--tabs <mode>` | Parallel mode: `auto` `iterm` `tmux` `bg` | `auto` |
+| `--no-color` | Disable colors | auto-detected |
+| `-h, --help` | Show help | -- |
 
 <details>
 <summary><strong>Color behavior</strong></summary>
 
-Colors are automatically enabled when both stdout and stderr are TTYs. They are disabled when:
-
-- Output is piped or redirected
-- `NO_COLOR=1` is set (per [no-color.org](https://no-color.org))
-- `PR_REVIEW_NO_COLOR=1` is set
-- `--no-color` flag is passed
+Colors are enabled when stdout/stderr are TTYs. Disabled by:
+- Piped or redirected output
+- `NO_COLOR=1` (per [no-color.org](https://no-color.org))
+- `PR_REVIEW_NO_COLOR=1`
+- `--no-color` flag
 
 </details>
 
@@ -167,273 +146,30 @@ Colors are automatically enabled when both stdout and stderr are TTYs. They are 
 
 ## Parallel Reviews
 
-Pass two or more PR numbers and the script auto-detects your terminal:
+Pass 2+ PR numbers and the terminal is auto-detected:
 
-| Terminal | What happens | Navigation |
-|----------|-------------|------------|
-| **iTerm2** | One named tab per PR | `Cmd+1-9` or `Cmd+Arrow` |
-| **tmux** | Session with named windows | `Ctrl+B n/p` or `Ctrl+B w` |
-| **Other** | Background processes with live status | Logs in `~/.pr_reviewer/` |
+| Terminal | Behavior | Navigation |
+|----------|----------|------------|
+| **iTerm2** | Named tab per PR | `Cmd+1-9` / `Cmd+Arrow` |
+| **tmux** | Session with named windows | `Ctrl+B n/p` / `Ctrl+B w` |
+| **Other** | Background with live status | Logs in `~/.reviewer/` |
 
-Override with `--tabs`:
-
-```bash
-./pr_review.sh 42 43 --tabs tmux    # Force tmux
-./pr_review.sh 42 43 --tabs bg      # Force background
-```
-
-When a review finishes, the tab clears and shows the completed review. Each tab provides quick commands:
-
-| Command | Action |
-|---------|--------|
-| `review` | Re-display the review |
-| `pdiff` | View the PR diff |
-| `files` | Show PR metadata and changed files |
-| `exit` | Close the tab |
-
----
-
-## How It Works
-
-```
-  PR #42
-    |
-    v
- +------------------+     +---------------------+     +---------------------+
- | Fetch PR metadata | --> | Create git worktree | --> | Copy env/config     |
- | and diff via gh   |     | ~/.pr_reviewer/     |     | files into worktree |
- +------------------+     +---------------------+     +---------------------+
-                                                              |
-                                                              v
-                                            +----------------------------------+
-                                            |     Claude Code Agent Team       |
-                                            |                                  |
-                                            |  +------------+ +-------------+  |
-                                            |  | Code       | | Security    |  |
-                                            |  | Quality    | | Reviewer    |  |
-                                            |  +------------+ +-------------+  |
-                                            |  +------------+ +-------------+  |
-                                            |  | Logic &    | | Architec-   |  |
-                                            |  | Correctness| | ture        |  |
-                                            |  +------------+ +-------------+  |
-                                            +----------------------------------+
-                                                              |
-                                                              v
-                                                      +---------------+
-                                                      |  REVIEW.md    |
-                                                      |  - Verdict    |
-                                                      |  - Test runs  |
-                                                      |  - Findings   |
-                                                      +---------------+
-```
-
-### Step by step
-
-1. **Fetches PR metadata and diff** -- uses `gh pr view` and `gh pr diff` to pull the title, description, branch names, and full unified diff for the PR.
-
-2. **Creates an isolated git worktree** -- runs `git fetch origin pull/<N>/head` then `git worktree add` to check out the PR branch at `~/.pr_reviewer/pr-<N>/`. This is a full, independent copy of the repo at the PR's commit -- your working branch is never touched. See [Git worktree storage](#git-worktree-storage) below.
-
-3. **Copies env/config files** -- git worktrees only contain tracked files. The script copies common untracked files (`.env`, `.npmrc`, etc.) from the main repo into the worktree so tests, linters, and builds work. A manifest is logged to `env-files-copied.log`.
-
-4. **Writes PR context** -- the diff and PR metadata are saved into a `.pr-review-context/` directory inside the worktree, giving Claude structured access to everything it needs.
-
-5. **Launches Claude Code** -- `cd`s into the worktree and invokes `claude` with a detailed prompt. Claude creates an agent team of 4 specialists (code quality, security, logic/correctness, architecture). Each specialist reads the diff, explores the source code, runs the test suite and linters, and produces categorized findings.
-
-6. **Generates `REVIEW.md`** -- the lead agent synthesizes all findings into `.pr-review-context/REVIEW.md` with an executive summary, test results, categorized findings, and a file-by-file breakdown.
-
-### Git worktree storage
-
-The script uses [git worktrees](https://git-scm.com/docs/git-worktree) to avoid interfering with your working directory. Worktrees are stored **outside your repo**, under `~/.pr_reviewer/` by default:
-
-```
-~/.pr_reviewer/                  # configurable with --dir
-├── pr-42/                       # full checkout of PR #42's branch
-│   ├── (all tracked repo files)
-│   └── .pr-review-context/      # created by the script
-│       ├── pr.diff              # full unified diff
-│       ├── pr-info.md           # PR metadata (title, author, branch, description)
-│       ├── REVIEW.md            # final review output
-│       └── env-files-copied.log # manifest of copied env/config files
-├── pr-43/                       # another PR review (if running in parallel)
-├── .lock-pr-42                  # lockfile to prevent duplicate runs (auto-removed)
-└── .lock-pr-43
-```
-
-Key points about worktrees:
-
-- **Your working branch is never modified.** Each worktree is an independent checkout linked to the same `.git` directory. You can keep coding while a review runs.
-- **Worktrees are created fresh** each time. If a stale worktree from a previous run exists, the script removes it first.
-- **Lockfiles** prevent two reviews of the same PR from running simultaneously. They are cleaned up automatically when the script exits.
-- **Cleanup** is optional. Pass `--cleanup` to remove the worktree after the review finishes, or remove them manually with `rm -rf ~/.pr_reviewer/pr-<N>` and `git worktree prune`.
+Each completed tab provides quick commands: `review`, `pdiff`, `files`, `exit`.
 
 ---
 
 ## Examples
 
 ```bash
-# Standard review
-./pr_review.sh 42
-
-# Three PRs in parallel tabs
-./pr_review.sh 42 43 44
-
-# More thorough review with auto-cleanup
-./pr_review.sh 42 --max-turns 75 --cleanup
-
-# Non-interactive, save output to file
-./pr_review.sh 42 -o review-42.md
-
-# Different repo, extra env files, subagents mode
-./pr_review.sh 42 --repo myorg/myrepo -e ".env.staging" --no-teams
-
-# Plain output for CI pipelines
-NO_COLOR=1 ./pr_review.sh 42 -o review.md
+reviewer.sh 42                               # single PR review
+reviewer.sh 42 43 44                         # parallel tabs
+reviewer.sh 42 -m opus -tm sonnet            # opus lead, sonnet teammates
+reviewer.sh 42 --max-turns 75 --cleanup      # deeper review, auto-cleanup
+reviewer.sh 42 -o review.md                  # non-interactive, save to file
+reviewer.sh 42 --repo myorg/myrepo           # different repo
+reviewer.sh 42 -e ".env.staging" --no-teams  # custom env, subagent mode
+NO_COLOR=1 reviewer.sh 42 -o out.md          # plain output for CI
 ```
-
----
-
-## Environment Files
-
-Git worktrees only contain tracked files. The script automatically copies common untracked files from the main repo so that tests, linters, and builds work inside the worktree.
-
-<details>
-<summary><strong>Default file patterns copied</strong></summary>
-
-- `.env`, `.env.local`, `.env.test`, `.env.development`, `.env.development.local`, `.env.test.local`, `.env.production.local`, `.env.docker`
-- `.npmrc`, `.yarnrc`, `.yarnrc.yml`, `.pnp.cjs`, `.pnp.loader.mjs`
-- `.python-version`, `pyrightconfig.json`
-- `.ruby-version`, `.tool-versions`
-- `config/master.key`, `config/credentials.yml.enc`
-- `local.properties`, `.air.toml`
-- `docker-compose.override.yml`, `.docker/config.json`
-- `.vscode/settings.json`, `.vscode/launch.json`, `.idea/workspace.xml`
-- `*.auto.tfvars`, `terraform.tfvars`
-- `Procfile.dev`
-- Deep scan (4 directory levels) for per-service `.env` files
-
-</details>
-
-**Add custom patterns:**
-
-```bash
-./pr_review.sh 42 -e ".env.staging,secrets/local.json"
-```
-
-**Skip entirely:**
-
-```bash
-./pr_review.sh 42 --no-env-copy
-```
-
----
-
-## Testing
-
-```bash
-./test_pr_review.sh
-```
-
-Runs **160 tests** covering:
-
-- ANSI color validation and rendering
-- TTY and `NO_COLOR` detection
-- iTerm2 escape sequences
-- Argument parsing and edge cases
-- macOS compatibility
-- Safety checks and lockfile handling
-- Helper functions
-- Worktree creation and cleanup logic
-- Parallel mode orchestration
-
----
-
-## Troubleshooting
-
-<details>
-<summary><strong>"gh" is not authenticated</strong></summary>
-
-```
-FATAL: GitHub CLI is not authenticated. Run: gh auth login
-```
-
-Run `gh auth login` and follow the prompts to authenticate with your GitHub account.
-
-</details>
-
-<details>
-<summary><strong>Stale lockfile blocking a review</strong></summary>
-
-```
-FATAL: Another review of PR #42 is already running (PID 12345).
-```
-
-If the previous review crashed, the lockfile may be stale. Remove it manually:
-
-```bash
-rm ~/.pr_reviewer/.lock-pr-42
-```
-
-The script detects stale lockfiles automatically when the referenced PID is no longer running, but in rare cases manual removal may be needed.
-
-</details>
-
-<details>
-<summary><strong>Worktree already exists</strong></summary>
-
-The script automatically removes stale worktrees before creating new ones. If you encounter persistent issues:
-
-```bash
-# Remove a specific worktree
-rm -rf ~/.pr_reviewer/pr-42
-git worktree prune
-
-# Remove all review worktrees
-rm -rf ~/.pr_reviewer
-```
-
-</details>
-
-<details>
-<summary><strong>Claude times out or hits turn limit</strong></summary>
-
-Increase the turn budget:
-
-```bash
-./pr_review.sh 42 --max-turns 75
-```
-
-The default of 50 turns works for most PRs. Large PRs (500+ lines changed) may benefit from 75--100 turns.
-
-</details>
-
-<details>
-<summary><strong>Tests fail in the worktree</strong></summary>
-
-The worktree may be missing untracked configuration files. Check which files were copied:
-
-```bash
-cat ~/.pr_reviewer/pr-42/.pr-review-context/env-files-copied.log
-```
-
-Add missing patterns with `-e`:
-
-```bash
-./pr_review.sh 42 -e ".env.custom,config/local.yml"
-```
-
-</details>
-
----
-
-## Security
-
-This tool has security implications you should be aware of:
-
-- **`--dangerously-skip-permissions`** is enabled by default, giving Claude autonomous access to run commands in the worktree. Use `--no-skip-permissions` to require manual approval for each tool invocation.
-- **Environment files** (`.env`, `config/master.key`, etc.) are copied into worktrees. These may contain secrets. Worktrees are created under `~/.pr_reviewer/` with standard file permissions.
-- **Worktree isolation** means the review cannot modify your working branch, but the agent can execute arbitrary commands within the worktree directory.
-
-> **Recommendation:** Review the [default env patterns](#environment-files) and use `--no-env-copy` if your project contains highly sensitive credentials.
 
 ---
 
@@ -441,49 +177,91 @@ This tool has security implications you should be aware of:
 
 ```
 .
-├── pr_review.sh          # Main script (~1100 lines)
-├── test_pr_review.sh     # Test suite (160 tests)
-├── README.md             # This file
-└── ~/.pr_reviewer/       # Created at runtime
-    ├── pr-42/            # Worktree for PR #42
-    │   └── .pr-review-context/
-    │       ├── pr.diff           # Full PR diff
-    │       ├── pr-info.md        # PR metadata and description
-    │       ├── REVIEW.md         # Final review output
-    │       └── env-files-copied.log  # Manifest of copied files
-    └── .lock-pr-42       # Lockfile (auto-removed)
+├── reviewer.sh           # Main script
+├── test_reviewer.sh      # Test suite (219 tests)
+└── README.md
+
+~/.reviewer/              # Created at runtime (configurable with --dir)
+├── pr-42/                # Isolated worktree for PR #42
+│   ├── (repo files)
+│   └── .pr-review-context/
+│       ├── pr.diff
+│       ├── pr-info.md
+│       ├── REVIEW.md     # Final review output
+│       └── env-files-copied.log
+└── .lock-pr-42           # Prevents duplicate runs (auto-removed)
 ```
+
+---
+
+## Environment Files
+
+Worktrees only contain tracked files. The script copies common untracked files (`.env`, `.npmrc`, `config/master.key`, ...) so tests and builds work.
+
+```bash
+reviewer.sh 42 -e ".env.staging,secrets/local.json"  # add patterns
+reviewer.sh 42 --no-env-copy                          # skip entirely
+```
+
+<details>
+<summary><strong>Default patterns</strong></summary>
+
+`.env*`, `.npmrc`, `.yarnrc`, `.yarnrc.yml`, `.pnp.cjs`, `.python-version`, `.ruby-version`, `.tool-versions`, `config/master.key`, `config/credentials.yml.enc`, `local.properties`, `docker-compose.override.yml`, `.vscode/settings.json`, `.idea/workspace.xml`, `*.auto.tfvars`, `terraform.tfvars`, `Procfile.dev`, plus a 4-level deep scan for per-service `.env` files.
+
+</details>
+
+---
+
+## Testing
+
+```bash
+./test_reviewer.sh              # run all 219 tests
+./test_reviewer.sh "Teammate"   # filter by section name
+```
+
+Covers: ANSI colors, TTY/NO_COLOR detection, iTerm2 escapes, argument parsing, edge cases, macOS compat, safety, helpers, worktree logic, parallel mode, env file copying, model validation, missing-arg guards.
+
+---
+
+## Security
+
+- **Autonomous mode** is on by default (`--dangerously-skip-permissions`). Use `--no-skip-permissions` for manual approval.
+- **Env files** containing secrets are copied into worktrees. Use `--no-env-copy` for sensitive projects.
+- **Worktree isolation** prevents modifications to your working branch, but the agent can execute commands within the worktree.
+
+---
+
+## Troubleshooting
+
+| Problem | Solution |
+|---------|----------|
+| `gh` not authenticated | `gh auth login` |
+| Stale lockfile | `rm ~/.reviewer/.lock-pr-<N>` |
+| Worktree issues | `rm -rf ~/.reviewer/pr-<N> && git worktree prune` |
+| Turn limit hit | `reviewer.sh 42 --max-turns 75` |
+| Missing env files | Check `~/.reviewer/pr-<N>/.pr-review-context/env-files-copied.log`, add with `-e` |
 
 ---
 
 ## Uninstall
 
 ```bash
-# Remove review worktrees and data
-rm -rf ~/.pr_reviewer
-
-# Remove the script
-rm -rf /path/to/reviewer
-
-# (Optional) Remove Claude Code CLI
-brew uninstall claude
+rm -rf ~/.reviewer          # remove worktrees and data
+rm -rf /path/to/reviewer    # remove the script
 ```
 
 ---
 
 ## Contributing
 
-Contributions are welcome. Please:
+1. Fork, branch, make changes
+2. Run `./test_reviewer.sh` — all 219 tests must pass
+3. Submit a pull request
 
-1. Fork the repository
-2. Create a feature branch (`git checkout -b feature/my-change`)
-3. Run the test suite (`./test_pr_review.sh`) and ensure all 160 tests pass
-4. Submit a pull request
-
-For bugs and feature requests, open an [issue](https://github.com/Reidmen/reviewer/issues).
+Issues and feature requests: [github.com/Reidmen/reviewer/issues](https://github.com/Reidmen/reviewer/issues)
 
 ---
 
 ## License
 
-MIT License. See [LICENSE](LICENSE) for details.
+MIT

--- a/reviewer.sh
+++ b/reviewer.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 # ============================================================================
-#  pr_review.sh — AI-powered PR code review with Claude Code agent teams
+#  reviewer.sh — AI-powered PR code review with Claude Code agent teams
 # ============================================================================
 #
-#  Usage:  pr_review.sh <PR_NUMBER...> [OPTIONS]
+#  Usage:  reviewer.sh <PR_NUMBER...> [OPTIONS]
 #
-#  Checks out a PR into an isolated git worktree (~/.pr_reviewer/pr-<N>/),
+#  Checks out a PR into an isolated git worktree (~/.reviewer/pr-<N>/),
 #  copies untracked env/config files so tests work, then launches Claude Code
 #  with 4 specialist reviewers (code quality, security, logic, architecture).
 #
@@ -38,15 +38,13 @@ else
     RED=''; GREEN=''; YELLOW=''; BLUE=''; CYAN=''; BOLD=''; DIM=''; RESET=''
 fi
 
-info()  { printf "%s[INFO]%s  %s\n" "$BLUE" "$RESET" "$*"; }
-ok()    { printf "%s[OK]%s    %s\n" "$GREEN" "$RESET" "$*"; }
-warn()  { printf "%s[WARN]%s  %s\n" "$YELLOW" "$RESET" "$*"; }
-error() { printf "%s[ERROR]%s %s\n" "$RED" "$RESET" "$*" >&2; }
+info()  { printf "  %s●%s  %s\n" "$BLUE" "$RESET" "$*"; }
+ok()    { printf "  %s✓%s  %s\n" "$GREEN" "$RESET" "$*"; }
+warn()  { printf "  %s⚠%s  %s\n" "$YELLOW" "$RESET" "$*"; }
+error() { printf "  %s✖%s  %s\n" "$RED" "$RESET" "$*" >&2; }
 fatal() { error "$@"; exit 1; }
-step()  { printf "\n%s%s▸ %s%s\n" "$CYAN" "$BOLD" "$*" "$RESET"; }
+step()  { printf "\n  %s%s▸ %s%s\n" "$CYAN" "$BOLD" "$*" "$RESET"; }
 
-# Box-line helper: prints a single line wrapped in BOLD+CYAN, with RESET.
-_boxln() { printf "%s%s%s%s\n" "$BOLD" "$CYAN" "$1" "$RESET"; }
 
 # ── Defaults ────────────────────────────────────────────────────────────────
 PR_NUMBERS=()
@@ -81,97 +79,101 @@ ENV_COPY_MAX_SIZE=$((5 * 1024 * 1024))  # 5 MB per file
 
 # ── Parse arguments ─────────────────────────────────────────────────────────
 usage() {
-    cat <<'HELPTEXT'
-pr_review.sh — AI-powered code review with Claude Code agent teams
-
-USAGE
-  pr_review.sh <PR_NUMBER...> [OPTIONS]
-
-  Run from inside any git repo with a GitHub remote. The script auto-detects
-  the repository, fetches the PR, and creates an isolated worktree.
-
-EXAMPLES
-  pr_review.sh 42                              # review a PR
-  pr_review.sh 42 43 44                        # three PRs in parallel tabs
-  pr_review.sh 42 --max-turns 75 --cleanup     # deeper review, auto-cleanup
-  pr_review.sh 42 -o review.md                 # save to file (non-interactive)
-  pr_review.sh 42 --repo myorg/myrepo          # review a PR from another repo
-  pr_review.sh 42 -e ".env.staging" --no-teams # custom env, subagent mode
-  NO_COLOR=1 pr_review.sh 42 -o out.md         # plain output for CI pipelines
-
-OPTIONS
-  Core
-    -r, --repo <owner/repo>  Target repository (default: auto-detected)
-    -m, --model <model>      Claude model for lead agent (default: opus)
-    -tm, --teammate-model <model>
-                             Model for teammate agents (default: same as --model)
-    -b, --max-turns <N>      Max agentic turns per PR (default: 50, range: 30–75)
-    -h, --help               Show this help
-
-  Output
-    -o, --output <path>      Write review to file (non-interactive, single-PR)
-    -c, --cleanup            Remove worktree after review completes
-    --no-color               Disable colors (also: NO_COLOR=1, PR_REVIEW_NO_COLOR=1)
-
-  Agent
-    -t, --no-teams           Use subagents instead of agent teams
-    --no-skip-permissions    Require manual approval for each tool use
-
-  Environment
-    -e, --env-files <globs>  Extra file patterns to copy (comma-separated)
-                             Example: -e ".env.staging,config/local.yml"
-    --no-env-copy            Skip copying .env and config files into worktree
-
-  Terminal
-    -d, --dir <path>         Worktree parent directory (default: ~/.pr_reviewer/)
-    --tabs <mode>            Parallel mode: auto | iterm | tmux | bg
-
-PARALLEL REVIEWS
-  Pass 2+ PR numbers and the terminal is auto-detected:
-
-    iTerm2    Named tabs, navigate with ⌘+←/→ or ⌘+1-9
-    tmux      Named windows in a session, Ctrl+B n/p or Ctrl+B w
-    Other     Background processes with live status dashboard
-
-  Override: pr_review.sh 42 43 --tabs tmux
-
-  Each completed tab provides quick commands:
-    review    Re-display the review      pdiff    View the PR diff
-    files     PR metadata & file list    exit     Close the tab
-
-ENVIRONMENT FILES
-  Git worktrees only contain tracked files. The script copies common untracked
-  files (.env, .npmrc, config/master.key, …) so tests and builds work.
-  Add custom patterns: -e ".env.staging,secrets/local.json"
-  Skip entirely: --no-env-copy
-  Manifest: ~/.pr_reviewer/pr-<N>/.pr-review-context/env-files-copied.log
-
-OUTPUT
-  Reviews are saved to: ~/.pr_reviewer/pr-<N>/.pr-review-context/REVIEW.md
-  With -o <path>, also written to the specified file.
-
-REQUIREMENTS
-  brew install gh jq claude && gh auth login
-HELPTEXT
+    local B="$BOLD" C="$CYAN" D="$DIM" G="$GREEN" R="$RESET"
+    printf "\n"
+    printf "  %s%s◆ reviewer%s  %s· AI-powered code review with Claude%s\n" "$B" "$C" "$R" "$D" "$R"
+    printf "\n"
+    printf "  %s%sUSAGE%s\n" "$B" "$C" "$R"
+    printf "    reviewer.sh <PR_NUMBER...> [OPTIONS]\n"
+    printf "\n"
+    printf "    Run from inside any git repo with a GitHub remote. The script auto-detects\n"
+    printf "    the repository, fetches the PR, and creates an isolated worktree.\n"
+    printf "\n"
+    printf "  %s%sEXAMPLES%s\n" "$B" "$C" "$R"
+    printf "    %sreviewer.sh 42%s                                %s# review a PR%s\n"                    "$B" "$R" "$D" "$R"
+    printf "    %sreviewer.sh 42 43 44%s                          %s# three PRs in parallel tabs%s\n"     "$B" "$R" "$D" "$R"
+    printf "    %sreviewer.sh 42 --max-turns 75 --cleanup%s       %s# deeper review, auto-cleanup%s\n"    "$B" "$R" "$D" "$R"
+    printf "    %sreviewer.sh 42 -o review.md%s                   %s# save to file (non-interactive)%s\n" "$B" "$R" "$D" "$R"
+    printf "    %sreviewer.sh 42 --repo myorg/myrepo%s            %s# review a PR from another repo%s\n"  "$B" "$R" "$D" "$R"
+    printf "    %sreviewer.sh 42 -m opus -tm sonnet%s             %s# opus lead, sonnet teammates%s\n"    "$B" "$R" "$D" "$R"
+    printf "    %sreviewer.sh 42 -e \".env.staging\" --no-teams%s   %s# custom env, subagent mode%s\n"    "$B" "$R" "$D" "$R"
+    printf "    %sNO_COLOR=1 reviewer.sh 42 -o out.md%s           %s# plain output for CI pipelines%s\n"  "$B" "$R" "$D" "$R"
+    printf "\n"
+    printf "  %s%sOPTIONS%s\n" "$B" "$C" "$R"
+    printf "    %sCore%s\n" "$D" "$R"
+    printf "      %s-r, --repo%s <owner/repo>  Target repository %s(default: auto-detected)%s\n"        "$B" "$R" "$D" "$R"
+    printf "      %s-m, --model%s <model>      Claude model for lead agent %s(default: opus)%s\n"       "$B" "$R" "$D" "$R"
+    printf "      %s-tm, --teammate-model%s <model>\n"                                                  "$B" "$R"
+    printf "                               Model for teammate agents %s(default: same as --model)%s\n"  "$D" "$R"
+    printf "      %s-b, --max-turns%s <N>      Max agentic turns per PR %s(default: 50, range: 30–75)%s\n" "$B" "$R" "$D" "$R"
+    printf "      %s-h, --help%s               Show this help\n"                                        "$B" "$R"
+    printf "\n"
+    printf "    %sOutput%s\n" "$D" "$R"
+    printf "      %s-o, --output%s <path>      Write review to file %s(non-interactive, single-PR)%s\n" "$B" "$R" "$D" "$R"
+    printf "      %s-c, --cleanup%s            Remove worktree after review completes\n"                "$B" "$R"
+    printf "      %s--no-color%s               Disable colors %s(also: NO_COLOR=1, PR_REVIEW_NO_COLOR=1)%s\n" "$B" "$R" "$D" "$R"
+    printf "\n"
+    printf "    %sAgent%s\n" "$D" "$R"
+    printf "      %s-t, --no-teams%s           Use subagents instead of agent teams\n"                  "$B" "$R"
+    printf "      %s--no-skip-permissions%s    Require manual approval for each tool use\n"             "$B" "$R"
+    printf "\n"
+    printf "    %sEnvironment%s\n" "$D" "$R"
+    printf "      %s-e, --env-files%s <globs>  Extra file patterns to copy %s(comma-separated)%s\n"     "$B" "$R" "$D" "$R"
+    printf "                               Example: -e \".env.staging,config/local.yml\"\n"
+    printf "      %s--no-env-copy%s            Skip copying .env and config files into worktree\n"      "$B" "$R"
+    printf "\n"
+    printf "    %sTerminal%s\n" "$D" "$R"
+    printf "      %s-d, --dir%s <path>         Worktree parent directory %s(default: ~/.reviewer/)%s\n" "$B" "$R" "$D" "$R"
+    printf "      %s--tabs%s <mode>            Parallel mode: auto | iterm | tmux | bg\n"               "$B" "$R"
+    printf "\n"
+    printf "  %s%sPARALLEL REVIEWS%s\n" "$B" "$C" "$R"
+    printf "    Pass 2+ PR numbers and the terminal is auto-detected:\n"
+    printf "\n"
+    printf "      %siTerm2%s    Named tabs, navigate with %s⌘+←/→%s or %s⌘+1-9%s\n"                   "$G" "$R" "$B" "$R" "$B" "$R"
+    printf "      %stmux%s      Named windows in a session, %sCtrl+B n/p%s or %sCtrl+B w%s\n"          "$G" "$R" "$B" "$R" "$B" "$R"
+    printf "      %sOther%s     Background processes with live status dashboard\n"                      "$G" "$R"
+    printf "\n"
+    printf "    Override: %sreviewer.sh 42 43 --tabs tmux%s\n" "$B" "$R"
+    printf "\n"
+    printf "    Each completed tab provides quick commands:\n"
+    printf "      %sreview%s    Re-display the review      %spdiff%s    View the PR diff\n"             "$B" "$R" "$B" "$R"
+    printf "      %sfiles%s     PR metadata & file list    %sexit%s     Close the tab\n"                "$B" "$R" "$B" "$R"
+    printf "\n"
+    printf "  %s%sENVIRONMENT FILES%s\n" "$B" "$C" "$R"
+    printf "    Git worktrees only contain tracked files. The script copies common untracked\n"
+    printf "    files (.env, .npmrc, config/master.key, …) so tests and builds work.\n"
+    printf "    Add custom patterns: %s-e \".env.staging,secrets/local.json\"%s\n" "$B" "$R"
+    printf "    Skip entirely: %s--no-env-copy%s\n" "$B" "$R"
+    printf "    Manifest: %s~/.reviewer/pr-<N>/.pr-review-context/env-files-copied.log%s\n" "$D" "$R"
+    printf "\n"
+    printf "  %s%sOUTPUT%s\n" "$B" "$C" "$R"
+    printf "    Reviews are saved to: %s~/.reviewer/pr-<N>/.pr-review-context/REVIEW.md%s\n" "$D" "$R"
+    printf "    With %s-o <path>%s, also written to the specified file.\n" "$B" "$R"
+    printf "\n"
+    printf "  %s%sREQUIREMENTS%s\n" "$B" "$C" "$R"
+    printf "    brew install gh jq claude && gh auth login\n"
+    printf "\n"
     exit 0
 }
+
+_need_arg() { [[ $# -ge 2 && -n "${2:-}" ]] || fatal "$1 requires a value"; }
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         -h|--help)             usage ;;
-        -r|--repo)             REPO="$2"; shift 2 ;;
-        -d|--dir)              WORKTREE_PARENT="$2"; shift 2 ;;
-        -e|--env-files)        EXTRA_ENV_PATTERNS="$2"; shift 2 ;;
-        -m|--model)            MODEL="$2"; shift 2 ;;
-        -tm|--teammate-model)  TEAMMATE_MODEL="$2"; shift 2 ;;
-        -b|--max-turns)         MAX_TURNS="$2"; shift 2 ;;
-        -o|--output)           OUTPUT_FILE="$2"; shift 2 ;;
+        -r|--repo)             _need_arg "$@"; REPO="$2"; shift 2 ;;
+        -d|--dir)              _need_arg "$@"; WORKTREE_PARENT="$2"; shift 2 ;;
+        -e|--env-files)        _need_arg "$@"; EXTRA_ENV_PATTERNS="$2"; shift 2 ;;
+        -m|--model)            _need_arg "$@"; MODEL="$2"; shift 2 ;;
+        -tm|--teammate-model)  _need_arg "$@"; TEAMMATE_MODEL="$2"; shift 2 ;;
+        -b|--max-turns)        _need_arg "$@"; MAX_TURNS="$2"; shift 2 ;;
+        -o|--output)           _need_arg "$@"; OUTPUT_FILE="$2"; shift 2 ;;
         -c|--cleanup)          CLEANUP=true; shift ;;
         -t|--no-teams)         USE_TEAMS=false; shift ;;
         --no-skip-permissions) SKIP_PERMISSIONS=false; shift ;;
         --no-env-copy)         COPY_ENV=false; shift ;;
         --no-color)            export NO_COLOR=1; RED=''; GREEN=''; YELLOW=''; BLUE=''; CYAN=''; BOLD=''; DIM=''; RESET=''; shift ;;
-        --tabs)                TAB_MODE="$2"; shift 2 ;;
+        --tabs)                _need_arg "$@"; TAB_MODE="$2"; shift 2 ;;
         --_single)             _SINGLE_MODE=true; shift ;;
         -*)                    fatal "Unknown option: $1  (use --help)" ;;
         *)
@@ -186,10 +188,22 @@ done
 [[ -z "$TEAMMATE_MODEL" ]] && TEAMMATE_MODEL="$MODEL"
 [[ ${#PR_NUMBERS[@]} -eq 0 ]] && fatal "Missing required argument: PR number(s). Usage: $(basename "$0") <PR_NUMBER...> [OPTIONS]"
 
+# ── Validate model names ──────────────────────────────────────────────────
+VALID_MODELS="opus sonnet haiku"
+_validate_model() {
+    local flag="$1" value="$2"
+    # shellcheck disable=SC2076
+    if [[ ! " $VALID_MODELS " =~ " $value " ]]; then
+        fatal "Invalid model for $flag: '${value}'. Valid models: ${VALID_MODELS}"
+    fi
+}
+_validate_model "--model" "$MODEL"
+_validate_model "--teammate-model" "$TEAMMATE_MODEL"
+
 # ── Opening banner (shown once, before any work) ─────────────────────────
 if [[ "$_SINGLE_MODE" == false ]]; then
     echo ""
-    printf "%s%s  pr-review.sh%s  %s— AI-powered code review%s\n" "$BOLD" "$CYAN" "$RESET" "$DIM" "$RESET"
+    printf "  %s%s◆ reviewer%s  %s· AI-powered code review with Claude%s\n" "$BOLD" "$CYAN" "$RESET" "$DIM" "$RESET"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -287,17 +301,17 @@ APPLESCRIPT
         done
 
         echo ""
-        _boxln "╔════════════════════════════════════════════════════════════╗"
-        printf "%s%s║  %-57s║%s\n" "$BOLD" "$CYAN" "${#PR_NUMBERS[@]} reviews launched in iTerm2 tabs" "$RESET"
-        _boxln "║                                                            ║"
-        _boxln "║  Navigation:                                               ║"
-        _boxln "║    ⌘ + ←/→           Switch between tabs                   ║"
-        _boxln "║    ⌘ + 1-9           Jump to tab by number                 ║"
-        _boxln "║    ⌘ + Shift + ]     Next tab                              ║"
-        _boxln "╚════════════════════════════════════════════════════════════╝"
+        printf "  %s%s───────────────────────────────────────────────────────%s\n" "$BOLD" "$CYAN" "$RESET"
+        printf "  %s%s  ${#PR_NUMBERS[@]} reviews launched in iTerm2 tabs%s\n" "$BOLD" "$GREEN" "$RESET"
+        echo ""
+        printf "  %sNavigation:%s\n" "$DIM" "$RESET"
+        printf "    %s⌘ + ←/→%s         Switch between tabs\n" "$BOLD" "$RESET"
+        printf "    %s⌘ + 1-9%s         Jump to tab by number\n" "$BOLD" "$RESET"
+        printf "    %s⌘ + Shift + ]%s   Next tab\n" "$BOLD" "$RESET"
+        printf "  %s%s───────────────────────────────────────────────────────%s\n" "$BOLD" "$CYAN" "$RESET"
         echo ""
         for i in "${!PR_NUMBERS[@]}"; do
-            printf "  Tab %d: %sPR #%s%s — %s\n" "$((i+1))" "$BOLD" "${PR_NUMBERS[$i]}" "$RESET" "${PR_TITLES[${PR_NUMBERS[$i]}]}"
+            printf "    %s%s%d%s  PR #%s%s%s — %s%s\n" "$DIM" "$CYAN" "$((i+1))" "$RESET" "$BOLD" "${PR_NUMBERS[$i]}" "$RESET" "${PR_TITLES[${PR_NUMBERS[$i]}]}" "$RESET"
         done
         exit 0
 
@@ -327,18 +341,18 @@ APPLESCRIPT
         done
 
         echo ""
-        _boxln "╔════════════════════════════════════════════════════════════╗"
-        printf "%s%s║  %-57s║%s\n" "$BOLD" "$CYAN" "${#PR_NUMBERS[@]} reviews in tmux: ${SESSION_NAME}" "$RESET"
-        _boxln "║                                                            ║"
-        _boxln "║  Navigation:                                               ║"
-        _boxln "║    Ctrl+B  n         Next window                           ║"
-        _boxln "║    Ctrl+B  p         Previous window                       ║"
-        _boxln "║    Ctrl+B  0-9       Jump to window by number              ║"
-        _boxln "║    Ctrl+B  w         Interactive window picker             ║"
-        _boxln "╚════════════════════════════════════════════════════════════╝"
+        printf "  %s%s───────────────────────────────────────────────────────%s\n" "$BOLD" "$CYAN" "$RESET"
+        printf "  %s%s  ${#PR_NUMBERS[@]} reviews in tmux: ${SESSION_NAME}%s\n" "$BOLD" "$GREEN" "$RESET"
+        echo ""
+        printf "  %sNavigation:%s\n" "$DIM" "$RESET"
+        printf "    %sCtrl+B  n%s       Next window\n" "$BOLD" "$RESET"
+        printf "    %sCtrl+B  p%s       Previous window\n" "$BOLD" "$RESET"
+        printf "    %sCtrl+B  0-9%s     Jump to window by number\n" "$BOLD" "$RESET"
+        printf "    %sCtrl+B  w%s       Interactive window picker\n" "$BOLD" "$RESET"
+        printf "  %s%s───────────────────────────────────────────────────────%s\n" "$BOLD" "$CYAN" "$RESET"
         echo ""
         for i in "${!PR_NUMBERS[@]}"; do
-            printf "  Window %d: %sPR #%s%s — %s\n" "$i" "$BOLD" "${PR_NUMBERS[$i]}" "$RESET" "${PR_TITLES[${PR_NUMBERS[$i]}]}"
+            printf "    %s%s%d%s  PR #%s%s%s — %s%s\n" "$DIM" "$CYAN" "$i" "$RESET" "$BOLD" "${PR_NUMBERS[$i]}" "$RESET" "${PR_TITLES[${PR_NUMBERS[$i]}]}" "$RESET"
         done
         echo ""
 
@@ -357,7 +371,7 @@ APPLESCRIPT
     elif [[ "$RESOLVED_TAB_MODE" == "bg" ]]; then
         ok "Launching ${#PR_NUMBERS[@]} reviews as background processes"
 
-        LOG_DIR="${WORKTREE_PARENT:-${HOME}/.pr_reviewer}"
+        LOG_DIR="${WORKTREE_PARENT:-${HOME}/.reviewer}"
         mkdir -p "$LOG_DIR"
 
         declare -A BG_PIDS
@@ -370,11 +384,11 @@ APPLESCRIPT
         done
 
         echo ""
-        _boxln "╔════════════════════════════════════════════════════════════╗"
-        printf "%s%s║  %-57s║%s\n" "$BOLD" "$CYAN" "${#PR_NUMBERS[@]} reviews running in background" "$RESET"
-        _boxln "║                                                            ║"
-        _boxln "║  Tip: install iTerm2 or tmux for tabbed parallel reviews   ║"
-        _boxln "╚════════════════════════════════════════════════════════════╝"
+        printf "  %s%s───────────────────────────────────────────────────────%s\n" "$BOLD" "$CYAN" "$RESET"
+        printf "  %s%s  ${#PR_NUMBERS[@]} reviews running in background%s\n" "$BOLD" "$GREEN" "$RESET"
+        echo ""
+        printf "  %sTip: install iTerm2 or tmux for tabbed parallel reviews%s\n" "$DIM" "$RESET"
+        printf "  %s%s───────────────────────────────────────────────────────%s\n" "$BOLD" "$CYAN" "$RESET"
         echo ""
 
         # Live status watcher
@@ -509,7 +523,7 @@ if git rev-parse --git-dir &>/dev/null 2>&1; then
     GIT_ROOT=$(git rev-parse --show-toplevel 2>/dev/null || git rev-parse --git-dir)
 else
     info "Not inside a git repo. Cloning $REPO..."
-    CLONE_DIR="/tmp/pr-review-repos/$(echo "$REPO" | tr '/' '-')"
+    CLONE_DIR="/tmp/reviewer-repos/$(echo "$REPO" | tr '/' '-')"
     if [[ ! -d "$CLONE_DIR" ]]; then
         gh repo clone "$REPO" "$CLONE_DIR" -- --bare 2>/dev/null \
             || gh repo clone "$REPO" "$CLONE_DIR" 2>/dev/null \
@@ -518,9 +532,9 @@ else
     GIT_ROOT="$CLONE_DIR"
 fi
 
-# ── Worktree parent: ~/.pr_reviewer/ ────────────────────────────────────────
+# ── Worktree parent: ~/.reviewer/ ────────────────────────────────────────
 if [[ -z "$WORKTREE_PARENT" ]]; then
-    WORKTREE_PARENT="${HOME}/.pr_reviewer"
+    WORKTREE_PARENT="${HOME}/.reviewer"
 fi
 WORKTREE_PARENT=$(cd "$(dirname "$WORKTREE_PARENT")" 2>/dev/null \
     && echo "$(pwd)/$(basename "$WORKTREE_PARENT")" || echo "$WORKTREE_PARENT")
@@ -542,19 +556,19 @@ if [[ -n "$WT_RELPATH" && "$WT_RELPATH" != ..* ]]; then
         GIT_EXCLUDE="${GIT_ROOT}/.git/info/exclude"
         if [[ -f "$GIT_EXCLUDE" ]]; then
             if ! grep -qF "$IGNORE_ENTRY" "$GIT_EXCLUDE" 2>/dev/null; then
-                printf '\n# PR review worktrees (auto-added by pr-review.sh)\n%s\n' "$IGNORE_ENTRY" >> "$GIT_EXCLUDE"
+                printf '\n# PR review worktrees (auto-added by reviewer.sh)\n%s\n' "$IGNORE_ENTRY" >> "$GIT_EXCLUDE"
                 printf "       %sAdded worktree to git exclude%s\n" "$DIM" "$RESET"
             fi
         else
             mkdir -p "$(dirname "$GIT_EXCLUDE")"
-            printf '# PR review worktrees (auto-added by pr-review.sh)\n%s\n' "$IGNORE_ENTRY" > "$GIT_EXCLUDE"
+            printf '# PR review worktrees (auto-added by reviewer.sh)\n%s\n' "$IGNORE_ENTRY" > "$GIT_EXCLUDE"
             printf "       %sAdded worktree to git exclude%s\n" "$DIM" "$RESET"
         fi
         GITIGNORE_FILE="${GIT_ROOT}/.gitignore"
         if [[ -f "$GITIGNORE_FILE" ]]; then
             if ! grep -qF "$IGNORE_ENTRY" "$GITIGNORE_FILE" 2>/dev/null; then
                 [[ -s "$GITIGNORE_FILE" && "$(tail -c1 "$GITIGNORE_FILE")" != "" ]] && echo "" >> "$GITIGNORE_FILE"
-                printf '\n# PR review worktrees (auto-added by pr-review.sh)\n%s\n' "$IGNORE_ENTRY" >> "$GITIGNORE_FILE"
+                printf '\n# PR review worktrees (auto-added by reviewer.sh)\n%s\n' "$IGNORE_ENTRY" >> "$GITIGNORE_FILE"
                 info "Also added to .gitignore (commit at your convenience)"
             fi
         fi
@@ -817,30 +831,33 @@ if [[ "$USE_TEAMS" == true ]]; then
 IMPORTANT: When creating each teammate agent, you MUST specify the model \"${TEAMMATE_MODEL}\" for all teammates. Use the model parameter to set each teammate to \"${TEAMMATE_MODEL}\". Do not use any other model."
 else
     AGENT_MODE="subagents"
-    read -r -d '' AGENTS_JSON <<AGENTS || true
+    # Quoted heredoc prevents accidental expansion of $ in prompt strings.
+    # TEAMMATE_MODEL is substituted explicitly below.
+    read -r -d '' AGENTS_JSON <<'AGENTS' || true
 {
   "code-quality-reviewer": {
     "description": "Analyzes code quality, readability, naming, DRY/SOLID, design patterns, code smells.",
     "prompt": "You are a senior code quality reviewer. Analyze the PR diff and source files. Focus on readability, naming, DRY/SOLID, design patterns, complexity. Run linters if available. Use 🔴/🟡/🟢/ℹ️. Diff at .pr-review-context/pr.diff.",
-    "tools": ["Read", "Grep", "Glob", "Bash"], "model": "${TEAMMATE_MODEL}"
+    "tools": ["Read", "Grep", "Glob", "Bash"], "model": "__TEAMMATE_MODEL__"
   },
   "security-reviewer": {
     "description": "Audits for security vulnerabilities, injection, auth, data exposure, OWASP Top 10.",
     "prompt": "You are a security reviewer. Audit for: injection, auth issues, data exposure, insecure defaults, missing validation, hardcoded secrets, OWASP Top 10. Use 🔴/🟡/🟢/ℹ️. Diff at .pr-review-context/pr.diff.",
-    "tools": ["Read", "Grep", "Glob", "Bash"], "model": "${TEAMMATE_MODEL}"
+    "tools": ["Read", "Grep", "Glob", "Bash"], "model": "__TEAMMATE_MODEL__"
   },
   "logic-reviewer": {
     "description": "Verifies business logic, edge cases, error handling, race conditions, tests.",
     "prompt": "You are a logic reviewer. Verify business logic, edge cases, error handling, race conditions, null safety, test coverage. Run the test suite. Use 🔴/🟡/🟢/ℹ️. Diff at .pr-review-context/pr.diff.",
-    "tools": ["Read", "Grep", "Glob", "Bash"], "model": "${TEAMMATE_MODEL}"
+    "tools": ["Read", "Grep", "Glob", "Bash"], "model": "__TEAMMATE_MODEL__"
   },
   "architecture-reviewer": {
     "description": "Evaluates architecture, API design, backward compat, performance, scalability.",
     "prompt": "You are an architecture reviewer. Evaluate architectural decisions, API design, backward compat, performance, scalability, dependency management. Use 🔴/🟡/🟢/ℹ️. Diff at .pr-review-context/pr.diff.",
-    "tools": ["Read", "Grep", "Glob", "Bash"], "model": "${TEAMMATE_MODEL}"
+    "tools": ["Read", "Grep", "Glob", "Bash"], "model": "__TEAMMATE_MODEL__"
   }
 }
 AGENTS
+    AGENTS_JSON="${AGENTS_JSON//__TEAMMATE_MODEL__/$TEAMMATE_MODEL}"
     CLAUDE_ARGS+=("--agents" "$AGENTS_JSON")
 fi
 
@@ -855,14 +872,23 @@ fi
 
 # ── Execute ────────────────────────────────────────────────────────────────
 echo ""
-_boxln "╔════════════════════════════════════════════════════════════╗"
+printf "  %s%s───────────────────────────────────────────────────────%s\n" "$BOLD" "$CYAN" "$RESET"
 echo ""
-printf "  %sPR #%s: %s%s\n" "$BOLD" "$PR_NUMBER" "$(echo "$PR_TITLE" | cut -c1-50)" "$RESET"
-printf "  %s@%s  ·  %s → %s  ·  +%s -%s  ·  %s file(s)%s\n" "$DIM" "$PR_AUTHOR" "$PR_HEAD" "$PR_BASE" "$PR_ADDS" "$PR_DELS" "$PR_FILES" "$RESET"
+printf "  %s%sPR #%s%s  %s%s\n" "$BOLD" "$CYAN" "$PR_NUMBER" "$RESET" "$BOLD$(echo "$PR_TITLE" | cut -c1-50)" "$RESET"
+printf "  %s@%s  ·  %s → %s  ·  %s+%s%s %s-%s%s  ·  %s file(s)%s\n" \
+    "$DIM" "$PR_AUTHOR" "$PR_HEAD" "$PR_BASE" \
+    "$GREEN" "$PR_ADDS" "$RESET$DIM" "$RED" "$PR_DELS" "$RESET$DIM" \
+    "$PR_FILES" "$RESET"
 echo ""
-printf "  %s%s%s\n" "$DIM" "$REVIEW_CONFIG_LINE" "$RESET"
+printf "  %s%s%s  %s%s%s  %s%s%s" \
+    "$CYAN" "${MODEL}$( [[ "$TEAMMATE_MODEL" != "$MODEL" ]] && printf " → %s" "$TEAMMATE_MODEL" )" "$RESET" \
+    "$BLUE" "${MAX_TURNS} turns" "$RESET" \
+    "$GREEN" "$AGENT_MODE" "$RESET"
+[[ "$SKIP_PERMISSIONS" == true ]] && printf "  %s%sautonomous%s" "$YELLOW" "$BOLD" "$RESET"
+[[ -n "$OUTPUT_FILE" ]] && printf "  %s→ %s%s" "$DIM" "$OUTPUT_FILE" "$RESET"
 echo ""
-_boxln "╚════════════════════════════════════════════════════════════╝"
+echo ""
+printf "  %s%s───────────────────────────────────────────────────────%s\n" "$BOLD" "$CYAN" "$RESET"
 echo ""
 
 _set_tab_title "PR #${PR_NUMBER} ⟳ reviewing..."
@@ -978,7 +1004,7 @@ fi
 if [[ "$_SINGLE_MODE" == true && -d "$WORKTREE_DIR" && "$CLEANUP" == false ]]; then
     # Write a tiny rcfile that gives the user quick commands
     _sq() { printf '%s' "$1" | sed "s/'/'\\\\''/g"; }
-    SHELL_RC=$(mktemp /tmp/pr-review-rc-XXXXXX)
+    SHELL_RC=$(mktemp /tmp/reviewer-rc-XXXXXX)
     cat > "$SHELL_RC" <<RCEOF
 # Load user's normal shell config
 [[ -f ~/.bashrc ]] && source ~/.bashrc 2>/dev/null
@@ -1027,13 +1053,15 @@ files() {
 
 # Welcome banner (compact — review already shown above)
 echo ""
-printf '\033[2m─────────────────────────────────────────────────\033[0m\n'
-printf '  \033[1mPR #$PR_NUMBER\033[0m worktree • Quick commands:\n'
-printf '    \033[1mreview\033[0m  — show the review again\n'
-printf '    \033[1mpdiff\033[0m   — view the PR diff\n'
-printf '    \033[1mfiles\033[0m   — PR metadata & file list\n'
-printf '    \033[1mexit\033[0m    — close this tab\n'
-printf '\033[2m─────────────────────────────────────────────────\033[0m\n'
+printf '  \033[1;36m───────────────────────────────────────────────\033[0m\n'
+printf '  \033[1;36m◆\033[0m \033[1mPR #$PR_NUMBER\033[0m worktree\n'
+echo ""
+printf '    \033[1;36mreview\033[0m   show the review again\n'
+printf '    \033[1;36mpdiff\033[0m    view the PR diff\n'
+printf '    \033[1;36mfiles\033[0m    PR metadata & file list\n'
+printf '    \033[1;36mexit\033[0m     close this tab\n'
+echo ""
+printf '  \033[1;36m───────────────────────────────────────────────\033[0m\n'
 echo ""
 RCEOF
     exec bash --rcfile "$SHELL_RC"

--- a/test_reviewer.sh
+++ b/test_reviewer.sh
@@ -1,15 +1,15 @@
 #!/usr/bin/env bash
 # ============================================================================
-#  test_pr_review.sh — Test suite for pr_review.sh
+#  test_reviewer.sh — Test suite for reviewer.sh
 # ============================================================================
 #  Covers: ANSI colors, TTY/NO_COLOR detection, argument parsing, edge cases,
 #  macOS compatibility, iTerm2 escapes, safety, helpers, rendering, worktree
 #  logic, parallel mode, behavioral tests, and integration with mocks.
 #
-#  Usage:  ./test_pr_review.sh [FILTER]
+#  Usage:  ./test_reviewer.sh [FILTER]
 #  Exit:   0 = all pass, 1 = failures
 #
-#  Filter: ./test_pr_review.sh "Edge"     # run only sections matching "Edge"
+#  Filter: ./test_reviewer.sh "Edge"     # run only sections matching "Edge"
 # ============================================================================
 set -uo pipefail
 
@@ -23,7 +23,7 @@ CYAN=$'\033[0;36m';   BOLD=$'\033[1m';      DIM=$'\033[2m';  RESET=$'\033[0m'
 ESC=$'\033'
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-SCRIPT="${SCRIPT_DIR}/pr_review.sh"
+SCRIPT="${SCRIPT_DIR}/reviewer.sh"
 TEST_TMP=""
 
 # ── Assertions ─────────────────────────────────────────────────────────────
@@ -112,7 +112,7 @@ section() {
 
 # ── Test fixtures ──────────────────────────────────────────────────────────
 setup_tmp() {
-    TEST_TMP=$(mktemp -d /tmp/pr-review-test-XXXXXX)
+    TEST_TMP=$(mktemp -d /tmp/reviewer-test-XXXXXX)
 }
 
 cleanup_tmp() {
@@ -124,14 +124,14 @@ trap 'cleanup_tmp' EXIT
 
 # ── Pre-flight ─────────────────────────────────────────────────────────────
 printf "%s%s╔════════════════════════════════════════════════════════════╗%s\n" "$BOLD" "$CYAN" "$RESET"
-printf "%s%s║  pr_review.sh — Test Suite                                ║%s\n" "$BOLD" "$CYAN" "$RESET"
+printf "%s%s║  reviewer.sh — Test Suite                                ║%s\n" "$BOLD" "$CYAN" "$RESET"
 if [[ -n "$FILTER" ]]; then
     printf "%s%s║  %-57s║%s\n" "$BOLD" "$CYAN" "Filter: $FILTER" "$RESET"
 fi
 printf "%s%s╚════════════════════════════════════════════════════════════╝%s\n" "$BOLD" "$CYAN" "$RESET"
 
 if [[ ! -f "$SCRIPT" ]]; then
-    printf "%sERROR: pr_review.sh not found at %s%s\n" "$RED" "$SCRIPT" "$RESET"
+    printf "%sERROR: reviewer.sh not found at %s%s\n" "$RED" "$SCRIPT" "$RESET"
     exit 1
 fi
 
@@ -254,7 +254,7 @@ if section "Argument Parsing"; then
     assert_exit_code "--no-color accepted" "$exit_code" 0
 
     # Verify all documented flags appear in help
-    for flag in --repo --dir --env-files --model --max-turns --output --cleanup \
+    for flag in --repo --dir --env-files --model --teammate-model --max-turns --output --cleanup \
                 --no-teams --no-skip-permissions --no-env-copy --no-color --tabs; do
         assert_contains "Help mentions $flag" "$output" "$flag"
     done
@@ -351,39 +351,35 @@ if section "Helper Functions"; then
         BLUE=$'\033[0;94m'; CYAN=$'\033[0;36m'; BOLD=$'\033[1m'
         DIM=$'\033[2m'; RESET=$'\033[0m'
         ESC=$'\033'
-        eval "$(grep -A1 '^info()\|^ok()\|^warn()\|^error()\|^step()\|^_boxln()' "$SCRIPT" | grep -v '^--$')"
+        eval "$(grep -A1 '^info()\|^ok()\|^warn()\|^error()\|^step()' "$SCRIPT" | grep -v '^--$')"
 
-        # Test each function
+        # Test each function — uses Unicode symbols (● ✓ ⚠ ✖ ▸)
         info_out=$(info "test message" 2>&1)
-        [[ "$info_out" == *"[INFO]"* && "$info_out" == *"test message"* && "$info_out" == *"$ESC"* ]] \
+        [[ "$info_out" == *"●"* && "$info_out" == *"test message"* && "$info_out" == *"$ESC"* ]] \
             && echo "info:OK" || echo "info:FAIL"
 
         ok_out=$(ok "success" 2>&1)
-        [[ "$ok_out" == *"[OK]"* && "$ok_out" == *"$ESC"* ]] \
+        [[ "$ok_out" == *"✓"* && "$ok_out" == *"$ESC"* ]] \
             && echo "ok:OK" || echo "ok:FAIL"
 
         warn_out=$(warn "careful" 2>&1)
-        [[ "$warn_out" == *"[WARN]"* ]] && echo "warn:OK" || echo "warn:FAIL"
+        [[ "$warn_out" == *"⚠"* ]] && echo "warn:OK" || echo "warn:FAIL"
 
         error_out=$(error "failure" 2>&1)
-        [[ "$error_out" == *"[ERROR]"* ]] && echo "error:OK" || echo "error:FAIL"
+        [[ "$error_out" == *"✖"* ]] && echo "error:OK" || echo "error:FAIL"
 
         step_out=$(step "phase" 2>&1)
         [[ "$step_out" == *"phase"* && "$step_out" == *"▸"* ]] \
             && echo "step:OK" || echo "step:FAIL"
 
-        box_out=$(_boxln "║ test ║" 2>&1)
-        [[ "$box_out" == *"test"* && "$box_out" == *"$ESC"* ]] \
-            && echo "boxln:OK" || echo "boxln:FAIL"
-
         # Test with empty colors (NO_COLOR simulation)
         RED=''; GREEN=''; YELLOW=''; BLUE=''; CYAN=''; BOLD=''; DIM=''; RESET=''
         eval "$(grep -A1 '^info()\|^ok()' "$SCRIPT" | grep -v '^--$')"
         plain_info=$(info "plain" 2>&1)
-        [[ "$plain_info" == *"[INFO]"* && "$plain_info" != *"$ESC"* ]] \
+        [[ "$plain_info" == *"●"* && "$plain_info" != *"$ESC"* ]] \
             && echo "nocolor_info:OK" || echo "nocolor_info:FAIL"
         plain_ok=$(ok "plain" 2>&1)
-        [[ "$plain_ok" == *"[OK]"* && "$plain_ok" != *"$ESC"* ]] \
+        [[ "$plain_ok" == *"✓"* && "$plain_ok" != *"$ESC"* ]] \
             && echo "nocolor_ok:OK" || echo "nocolor_ok:FAIL"
 
         # Test backslash safety: %s should NOT interpret \n
@@ -394,7 +390,7 @@ if section "Helper Functions"; then
             && echo "backslash_safe:OK" || echo "backslash_safe:FAIL"
     )
 
-    for fn in info ok warn error step boxln nocolor_info nocolor_ok backslash_safe; do
+    for fn in info ok warn error step nocolor_info nocolor_ok backslash_safe; do
         result=$(echo "$helper_results" | grep "^${fn}:" | cut -d: -f2)
         case "$fn" in
             nocolor_info) assert "info() works with empty colors" "$result" "OK" ;;
@@ -442,26 +438,24 @@ if section "Color Rendering (iTerm2)"; then
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════
-#  11. BOX ALIGNMENT (behavioral)
+#  11. VISUAL STRUCTURE (thin-line rules)
 # ═══════════════════════════════════════════════════════════════════════════
-if section "Box Alignment"; then
-    # Extract all _boxln lines and verify consistent width
-    box_widths=$(grep '_boxln "' "$SCRIPT" | sed 's/.*_boxln "//;s/".*//' | while read -r line; do
-        echo "${#line}"
-    done | sort -u)
-    unique_widths=$(echo "$box_widths" | wc -l | tr -d ' ')
-    assert "All _boxln lines same width" "$unique_widths" "1"
+if section "Visual Structure"; then
+    script_content=$(cat "$SCRIPT")
 
-    # Verify the consistent width value (62 = ╔ + 60 ═ + ╗)
-    box_width=$(echo "$box_widths" | head -1)
-    assert "Box width is 62 chars" "$box_width" "62"
+    # Uses modern thin-line rules (───) not heavy box-drawing (╔═╗║╚═╝)
+    assert_contains "Uses thin-line rules" "$script_content" "───"
+    assert_not_contains "No heavy box top" "$script_content" "╔═══"
+    assert_not_contains "No heavy box bottom" "$script_content" "╚═══"
 
-    # Verify printf dynamic lines use matching format width
-    dynamic_box_lines=$(grep 'printf.*║.*%-[0-9]' "$SCRIPT" | grep -oE '%-[0-9]+s' | sort -u)
-    for spec in $dynamic_box_lines; do
-        width=$(echo "$spec" | grep -oE '[0-9]+')
-        assert "Dynamic box content width ($spec) fits" "$(( width <= 57 ? 1 : 0 ))" "1"
-    done
+    # Status functions use Unicode symbols
+    assert_contains "info() uses ● symbol" "$(grep '^info()' "$SCRIPT")" "●"
+    assert_contains "ok() uses ✓ symbol" "$(grep '^ok()' "$SCRIPT")" "✓"
+    assert_contains "warn() uses ⚠ symbol" "$(grep '^warn()' "$SCRIPT")" "⚠"
+    assert_contains "error() uses ✖ symbol" "$(grep '^error()' "$SCRIPT")" "✖"
+
+    # Banner uses ◆ diamond
+    assert_contains "Banner uses ◆ symbol" "$script_content" "◆ reviewer"
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════
@@ -499,7 +493,6 @@ if section "Parallel Mode"; then
 
     assert_contains "PR diff command is pdiff" "$(grep 'pdiff()' "$SCRIPT")" "pdiff()"
     assert_not_contains "No diff() shadow" "$(grep -w 'diff()' "$SCRIPT")" "diff()"
-    assert_contains "Has _boxln() helper" "$(grep '_boxln()' "$SCRIPT")" "_boxln()"
 
     # Verify header comment matches RC file (pdiff not diff)
     header_section=$(head -200 "$SCRIPT")
@@ -527,7 +520,7 @@ if section "Integration: Env File Copy"; then
     echo "API_KEY=xxx" > "$GIT_ROOT/services/api/.env"
 
     # Create a worktree-like destination (outside GIT_ROOT's parent to avoid early return)
-    WORKTREE_BASE=$(mktemp -d /tmp/pr-review-wt-XXXXXX)
+    WORKTREE_BASE=$(mktemp -d /tmp/reviewer-wt-XXXXXX)
     WORKTREE="$WORKTREE_BASE/worktree"
     mkdir -p "$WORKTREE"
 
@@ -649,10 +642,16 @@ if section "Teammate Model Flag"; then
     # Passthrough handles the flag
     assert_contains "Passthrough passes --teammate-model" "$script_content" '--teammate-model'
 
-    # Subagent JSON uses TEAMMATE_MODEL variable (not hardcoded "opus")
+    # Subagent JSON uses __TEAMMATE_MODEL__ placeholder (not hardcoded "opus")
     agents_section=$(sed -n '/AGENTS_JSON/,/^AGENTS$/p' "$SCRIPT")
-    assert_contains "Subagent JSON uses TEAMMATE_MODEL" "$agents_section" 'TEAMMATE_MODEL'
+    assert_contains "Subagent JSON uses __TEAMMATE_MODEL__ placeholder" "$agents_section" '__TEAMMATE_MODEL__'
     assert_not_contains "Subagent JSON does not hardcode opus" "$agents_section" '"model": "opus"'
+
+    # Heredoc is quoted (safe against accidental $ expansion)
+    assert_contains "Heredoc uses quoted delimiter" "$agents_section" "<<'AGENTS'"
+
+    # Placeholder is substituted after heredoc
+    assert_contains "Placeholder substituted after heredoc" "$script_content" 'AGENTS_JSON="${AGENTS_JSON//__TEAMMATE_MODEL__/$TEAMMATE_MODEL}"'
 
     # Agent Teams mode has teammate model prompt section
     assert_contains "Agent Teams prompt includes Teammate Model section" "$script_content" '## Teammate Model'
@@ -661,14 +660,75 @@ if section "Teammate Model Flag"; then
     assert_contains "Config line shows teammates when different" "$script_content" '(teammates: ${TEAMMATE_MODEL})'
 
     # Behavioral: --teammate-model sonnet --help exits cleanly
-    tm_help_output=$(bash "$SCRIPT" --teammate-model sonnet --help 2>&1 || true)
+    tm_help_output=$(bash "$SCRIPT" --teammate-model sonnet --help 2>&1)
     tm_help_exit=$?
     assert "--teammate-model sonnet --help exits 0" "$tm_help_exit" "0"
 
     # Behavioral: -tm sonnet --help exits cleanly
-    tm_short_help_output=$(bash "$SCRIPT" -tm sonnet --help 2>&1 || true)
+    tm_short_help_output=$(bash "$SCRIPT" -tm sonnet --help 2>&1)
     tm_short_help_exit=$?
     assert "-tm sonnet --help exits 0" "$tm_short_help_exit" "0"
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  18. MODEL VALIDATION
+# ═══════════════════════════════════════════════════════════════════════════
+if section "Model Validation"; then
+    script_content=$(cat "$SCRIPT")
+
+    # Structural: validation function exists
+    assert_contains "_validate_model function exists" "$script_content" '_validate_model()'
+    assert_contains "VALID_MODELS list defined" "$script_content" 'VALID_MODELS='
+
+    # Behavioral: valid models accepted
+    for model in opus sonnet haiku; do
+        output=$(bash "$SCRIPT" --model "$model" --help 2>&1)
+        exit_code=$?
+        assert_exit_code "--model $model accepted" "$exit_code" 0
+    done
+
+    # Behavioral: invalid model rejected (PR number required to reach validation)
+    output=$(bash "$SCRIPT" 42 --model snonet 2>&1)
+    exit_code=$?
+    assert "Invalid --model exits non-zero" "$(( exit_code != 0 ? 1 : 0 ))" "1"
+    assert_contains "Invalid --model names the bad value" "$output" "snonet"
+
+    # Behavioral: invalid teammate model rejected
+    output=$(bash "$SCRIPT" 42 --teammate-model bogus 2>&1)
+    exit_code=$?
+    assert "Invalid --teammate-model exits non-zero" "$(( exit_code != 0 ? 1 : 0 ))" "1"
+    assert_contains "Invalid --teammate-model names the bad value" "$output" "bogus"
+
+    # Behavioral: valid teammate model accepted (--help exits before validation)
+    output=$(bash "$SCRIPT" --teammate-model haiku --help 2>&1)
+    exit_code=$?
+    assert_exit_code "--teammate-model haiku --help accepted" "$exit_code" 0
+fi
+
+# ═══════════════════════════════════════════════════════════════════════════
+#  19. MISSING ARGUMENT GUARD
+# ═══════════════════════════════════════════════════════════════════════════
+if section "Missing Argument Guard"; then
+    script_content=$(cat "$SCRIPT")
+
+    # Structural: _need_arg helper exists
+    assert_contains "_need_arg helper exists" "$script_content" '_need_arg()'
+
+    # Behavioral: each shift-2 flag produces a clean error when value is missing
+    for flag in --repo --dir --env-files --model --teammate-model --max-turns --output --tabs; do
+        output=$(bash "$SCRIPT" 42 "$flag" 2>&1)
+        exit_code=$?
+        assert "Missing value for $flag exits non-zero" "$(( exit_code != 0 ? 1 : 0 ))" "1"
+        assert_contains "$flag missing-value error is clear" "$output" "requires a value"
+    done
+
+    # Behavioral: short forms too
+    for flag in -r -d -e -m -tm -b -o; do
+        output=$(bash "$SCRIPT" 42 "$flag" 2>&1)
+        exit_code=$?
+        assert "Missing value for $flag exits non-zero" "$(( exit_code != 0 ? 1 : 0 ))" "1"
+        assert_contains "$flag missing-value error is clear" "$output" "requires a value"
+    done
 fi
 
 # ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Adds `-tm`/`--teammate-model` flag to control the model used for specialist teammate agents (code quality, security, logic, architecture)
- Defaults to the lead agent's model (`--model`) when omitted, ensuring teammates always use the intended model
- Renames `pr_review.sh` → `reviewer.sh`, `test_pr_review.sh` → `test_reviewer.sh`, and `~/.pr_reviewer/` → `~/.reviewer/`
- Fixes CLI bugs: exit-code test masking, heredoc shell expansion risk, missing-arg crashes on all shift-2 flags
- Adds model validation (`opus`, `sonnet`, `haiku`) with clear error messages
- Modernizes CLI visual output: Unicode status symbols (`● ✓ ⚠ ✖ ◆ ▸`), thin-line rules, color-coded launch summary, colored help text
- Rewrites README with concise workflow graph and updated references
- Expands test suite from 172 → 219 tests covering model validation, missing-arg guards, and visual structure

## Test plan

- [x] All 219 tests pass (`./test_reviewer.sh`)
- [x] `--help` shows the new `-tm, --teammate-model` flag with colored output
- [x] Invalid models (`--model snonet 42`) exit with clear error
- [x] Missing arguments (`--model` without value) exit with clear error
- [x] Default behavior unchanged when `--teammate-model` is omitted
- [x] Heredoc uses quoted `<<'AGENTS'` with `__TEAMMATE_MODEL__` placeholder (no shell expansion)
- [x] All file references updated from `pr_review` → `reviewer`

Closes #1
Closes #8
Closes #9
Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)