### PR TITLE
Fix all ShellCheck warnings

### DIFF
--- a/reviewer.sh
+++ b/reviewer.sh
@@ -687,7 +687,10 @@ if [[ "$COPY_ENV" == true ]]; then
 
     # Pass 1: pattern list
     for pattern in "${ALL_PATTERNS[@]}"; do
-        shopt -s nullglob; matches=( "$GIT_ROOT"/$pattern ); shopt -u nullglob
+        shopt -s nullglob
+        # shellcheck disable=SC2206
+        matches=( "$GIT_ROOT"/$pattern )
+        shopt -u nullglob
         for src_path in ${matches[@]+"${matches[@]}"}; do _try_copy "$src_path" "pattern"; done
     done
     # Pass 2: root .env*

--- a/test_reviewer.sh
+++ b/test_reviewer.sh
@@ -384,6 +384,7 @@ if section "Helper Functions"; then
 
         # Test backslash safety: %s should NOT interpret \n
         eval "$(grep -A1 '^info()' "$SCRIPT" | grep -v '^--$')"
+        # shellcheck disable=SC2034
         BLUE=$'\033[0;94m'; RESET=$'\033[0m'
         bs_out=$(info 'path/with\nslash' 2>&1)
         [[ "$bs_out" == *'with\nslash'* ]] \
@@ -526,12 +527,16 @@ if section "Integration: Env File Copy"; then
 
     # Extract and test the _try_copy function
     copy_results=$(
-        cd "$GIT_ROOT"
+        cd "$GIT_ROOT" || exit
         GIT_ROOT="$GIT_ROOT"
+        # shellcheck disable=SC2034
         WORKTREE_DIR="$WORKTREE"
+        # shellcheck disable=SC2034
         WORKTREE_PARENT="$WORKTREE_BASE"
+        # shellcheck disable=SC2034
         ENV_COPY_MAX_SIZE=$((5 * 1024 * 1024))
         ENV_COPIED=0
+        # shellcheck disable=SC2034
         ENV_SKIPPED=0
         ENV_COPY_LOG="$TEST_TMP/copy.log"
         : > "$ENV_COPY_LOG"
@@ -660,12 +665,12 @@ if section "Teammate Model Flag"; then
     assert_contains "Config line shows teammates when different" "$script_content" '(teammates: ${TEAMMATE_MODEL})'
 
     # Behavioral: --teammate-model sonnet --help exits cleanly
-    tm_help_output=$(bash "$SCRIPT" --teammate-model sonnet --help 2>&1)
+    bash "$SCRIPT" --teammate-model sonnet --help &>/dev/null
     tm_help_exit=$?
     assert "--teammate-model sonnet --help exits 0" "$tm_help_exit" "0"
 
     # Behavioral: -tm sonnet --help exits cleanly
-    tm_short_help_output=$(bash "$SCRIPT" -tm sonnet --help 2>&1)
+    bash "$SCRIPT" -tm sonnet --help &>/dev/null
     tm_short_help_exit=$?
     assert "-tm sonnet --help exits 0" "$tm_short_help_exit" "0"
 fi


### PR DESCRIPTION
## Summary
- Fix SC2206 warning in `reviewer.sh` by splitting glob expansion for proper `shellcheck disable` placement
- Fix SC2034 warnings in `test_reviewer.sh` for variables used via `eval`/source context
- Fix SC2164 warning by adding `|| exit` to `cd` in subshell
- Drop unused capture variables (`tm_help_output`, `tm_short_help_output`)

Both scripts now pass `shellcheck -S warning` with exit 0. All 219 tests pass.

## Test plan
- [x] `shellcheck -S warning reviewer.sh` exits 0
- [x] `shellcheck -S warning test_reviewer.sh` exits 0
- [x] `./test_reviewer.sh` — all 219 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)